### PR TITLE
Improvements to the descriptor-based tracker

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,11 +80,34 @@
 		<license.copyrightOwners>Friedrich Miescher Institute for Biomedical Research</license.copyrightOwners>
 		<releaseProfiles>deploy-to-scijava</releaseProfiles>
 
-		<imglib2.version>5.9.0-SNAPSHOT</imglib2.version>
-		<enforcer.skip>true</enforcer.skip>
+		<imglib2.version>5.9.0</imglib2.version>
 	</properties>
 
 	<dependencies>
+
+		<!-- SciJava dependencies -->
+		<dependency>
+			<groupId>org.scijava</groupId>
+			<artifactId>scijava-common</artifactId>
+		</dependency>
+
+		<!-- ImgLib2 dependencies -->
+		<dependency>
+			<groupId>net.imglib2</groupId>
+			<artifactId>imglib2</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>net.imglib2</groupId>
+			<artifactId>imglib2-algorithm</artifactId>
+		</dependency>
+
+		<!-- ImageJ dependencies -->
+		<dependency>
+			<groupId>net.imagej</groupId>
+			<artifactId>imagej-common</artifactId>
+		</dependency>
+
+		<!-- Fiji dependencies -->
 		<dependency>
 			<groupId>sc.fiji</groupId>
 			<artifactId>TrackMate_</artifactId>
@@ -97,11 +120,33 @@
 			<groupId>sc.fiji</groupId>
 			<artifactId>Descriptor_based_registration</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>sc.fiji</groupId>
+			<artifactId>Fiji_Plugins</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>sc.fiji</groupId>
+			<artifactId>SPIM_Registration</artifactId>
+		</dependency>
 
+		<!-- Third-party dependency -->
+		<dependency>
+			<groupId>mpicbg</groupId>
+			<artifactId>mpicbg</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.jdom</groupId>
+			<artifactId>jdom2</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>org.jgrapht</groupId>
 			<artifactId>jgrapht-core</artifactId>
 		</dependency>
+
 	</dependencies>
 
 	<repositories>

--- a/src/main/java/ch/fmi/trackmate/tracking/DistanceConstrainedDescriptorDistanceCostFunction.java
+++ b/src/main/java/ch/fmi/trackmate/tracking/DistanceConstrainedDescriptorDistanceCostFunction.java
@@ -1,0 +1,27 @@
+package ch.fmi.trackmate.tracking;
+
+import java.util.Map;
+
+import fiji.plugin.trackmate.Spot;
+import mpicbg.pointdescriptor.SimplePointDescriptor;
+import process.Particle;
+
+public class DistanceConstrainedDescriptorDistanceCostFunction extends DescriptorDistanceCostFunction {
+
+	private double squareDistanceThreshold;
+
+	public DistanceConstrainedDescriptorDistanceCostFunction(Map<Integer, SimplePointDescriptor<Particle>> spotMapping,
+			double distanceThreshold) {
+		super(spotMapping);
+		this.squareDistanceThreshold = distanceThreshold;
+	}
+
+	@Override
+	public double linkingCost(Spot s1, Spot s2) {
+		// return high cost when real distance above threshold
+		if (s1.squareDistanceTo(s2) > squareDistanceThreshold) return Double.POSITIVE_INFINITY;
+		// otherwise, return linking cost from superclass
+		return super.linkingCost(s1, s2);
+	}
+
+}

--- a/src/main/java/ch/fmi/trackmate/tracking/PointCloudRegistrationTrackerFactory.java
+++ b/src/main/java/ch/fmi/trackmate/tracking/PointCloudRegistrationTrackerFactory.java
@@ -26,9 +26,17 @@ public class PointCloudRegistrationTrackerFactory implements
 	SpotTrackerFactory
 {
 
-	private static final String INFO_TEXT = "<html>This tracker uses descriptor-based registration to link points between point clouds.</html>";
+	private static final String INFO_TEXT = "<html>"
+			+ "This tracker uses descriptor-based registration to link points between point clouds.<br/>"
+			+ "The descriptor-based registration is robust to outliers, which is beneficial"
+			+ "in terms of false positive detections, but has the drawback that some movements"
+			+ "that are very distinct from a 'common' ensemble movement might not be detected."
+			+ "Consider using the descriptor-based tracker that takes into account the local neighbors"
+			+ "of each spot and is supposed to better deal with small ensembles showing a different"
+			+ "movement from the entire point cloud."
+			+ "</html>";
 	private static final String KEY = "POINT_CLOUD_REGISTRATION_TRACKER";
-	private static final String NAME = "Point-cloud registration tracker (deprecated)";
+	private static final String NAME = "Point-cloud registration tracker (old)";
 
 	// Minimal number of inlier spots per comparison
 	static final String MIN_NUM_INLIERS = "MIN_NUM_INLIERS";


### PR DESCRIPTION
* (hopefully) better performance in distance matrix computation, by only computing the descriptor distance for pairs of spots if they're with the linking distance
* improve explanation for the old descriptor-based registration tracker
* add missing dependencies (revealed by `mvn dependency:analyze`)