### PR TITLE
Update to TrackMate v7.3+ API

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0  # Use the ref you want to point at
+    hooks:
+    -   id: check-xml

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>31.1.0</version>
+		<version>35.0.0</version>
 		<relativePath />
 	</parent>
 

--- a/src/main/java/ch/fmi/trackmate/tracking/DescriptorDistanceCostFunction.java
+++ b/src/main/java/ch/fmi/trackmate/tracking/DescriptorDistanceCostFunction.java
@@ -24,7 +24,7 @@ package ch.fmi.trackmate.tracking;
 import java.util.Map;
 
 import fiji.plugin.trackmate.Spot;
-import fiji.plugin.trackmate.tracking.sparselap.costfunction.CostFunction;
+import fiji.plugin.trackmate.tracking.jaqaman.costfunction.CostFunction;
 import mpicbg.pointdescriptor.SimplePointDescriptor;
 import process.Particle;
 

--- a/src/main/java/ch/fmi/trackmate/tracking/PointCloudRegistrationTrackerFactory.java
+++ b/src/main/java/ch/fmi/trackmate/tracking/PointCloudRegistrationTrackerFactory.java
@@ -233,4 +233,8 @@ public class PointCloudRegistrationTrackerFactory implements
 		return errorMessage;
 	}
 
+	@Override
+	public SpotTrackerFactory copy() {
+		return new PointCloudRegistrationTrackerFactory();
+	}
 }

--- a/src/main/java/ch/fmi/trackmate/tracking/PointDescriptorTracker.java
+++ b/src/main/java/ch/fmi/trackmate/tracking/PointDescriptorTracker.java
@@ -38,8 +38,8 @@ import fiji.plugin.trackmate.Logger;
 import fiji.plugin.trackmate.Spot;
 import fiji.plugin.trackmate.SpotCollection;
 import fiji.plugin.trackmate.tracking.SpotTracker;
-import fiji.plugin.trackmate.tracking.sparselap.costmatrix.JaqamanLinkingCostMatrixCreator;
-import fiji.plugin.trackmate.tracking.sparselap.linker.JaqamanLinker;
+import fiji.plugin.trackmate.tracking.jaqaman.costmatrix.JaqamanLinkingCostMatrixCreator;
+import fiji.plugin.trackmate.tracking.jaqaman.JaqamanLinker;
 import fiji.util.KDTree;
 import fiji.util.NNearestNeighborSearch;
 // TODO use multiview-reconstruction

--- a/src/main/java/ch/fmi/trackmate/tracking/PointDescriptorTrackerFactory.java
+++ b/src/main/java/ch/fmi/trackmate/tracking/PointDescriptorTrackerFactory.java
@@ -242,4 +242,9 @@ public class PointDescriptorTrackerFactory implements SpotTrackerFactory {
 		}
 		return true;
 	}
+
+	@Override
+	public SpotTrackerFactory copy() {
+		return new PointDescriptorTrackerFactory();
+	}
 }


### PR DESCRIPTION
* override abstract `copy()` method (introduced in TrackMate `v7.3.0`) in all `SpotTrackerFactory`s
* package name changes (`fiji.plugin.trackmate.tracking.jaqaman` introduced in TrackMate `v7.10.0`)